### PR TITLE
Hide aggregator attribute from WooCommerce attribute editor

### DIFF
--- a/includes/class-woo2etos.php
+++ b/includes/class-woo2etos.php
@@ -38,6 +38,7 @@ class Woo2Etos {
 
         // Worker
         add_action( 'woo2etos_sync_product', array( $this, 'worker_sync_product' ), 10, 3 );
+        add_filter( 'woocommerce_attribute_taxonomies', [ $this, 'hide_aggregator_attribute' ], 10, 1 );
     }
 
     public function register_recurring_sync() {
@@ -191,6 +192,19 @@ class Woo2Etos {
             }
         }
         return true;
+    }
+
+    public function hide_aggregator_attribute( $taxonomies ) {
+        if ( ! is_admin() ) return $taxonomies;
+        $screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+        if ( $screen && 'product' === $screen->id ) {
+            foreach ( $taxonomies as $i => $tax ) {
+                if ( WOO2ETOS_AT_TAX_SLUG === $tax->attribute_name ) {
+                    unset( $taxonomies[ $i ] );
+                }
+            }
+        }
+        return $taxonomies;
     }
 
     /** Handle dry-run or run via admin-post */


### PR DESCRIPTION
## Summary
- Hide aggregator attribute from WooCommerce attribute UI so it's not displayed in the "Add new attribute" list or editable rows

## Testing
- `php -l includes/class-woo2etos.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba829e05388327a4c9f6cf3ad3e4ba