### PR TITLE
Add GitHub and WordPress readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Woo2Etos
+
+Woo2Etos è un plugin per WooCommerce che aggrega tutti gli attributi che contengono "taglia" in un singolo attributo globale chiamato **Taglia** (`taglia-w2e`).
+
+## Funzionalità principali
+- Crea e mantiene sincronizzato l'attributo aggregatore per l'integrazione con il gestionale Etos.
+- Nasconde l'attributo `taglia-w2e` dall'editor prodotto e dalla scheda "Informazioni aggiuntive".
+- Utility per garantire l'esistenza dell'attributo e per rimuovere i termini vuoti.
+- Possibilità di avviare la sincronizzazione manualmente o tramite hook automatici e cron.
+
+## Requisiti
+- WordPress 6.0 o superiore.
+- PHP 7.4 o superiore.
+- WooCommerce attivo.
+
+## Installazione
+1. Copia la cartella del plugin in `wp-content/plugins/` oppure installalo tramite zip.
+2. Attiva il plugin da **Plugin** > **Aggiungi nuovo**.
+3. Vai su **WooCommerce > Woo2Etos** per configurare i settaggi e avviare la sincronizzazione.
+
+## Licenza
+Questo plugin è distribuito sotto la licenza [GPLv2 o successiva](https://www.gnu.org/licenses/gpl-2.0.html).
+
+## Contribuire
+Le issue e le pull request sono benvenute tramite GitHub. Prima di inviare una modifica, esegui i linters PHP:
+
+```bash
+php -l woo2etos.php
+php -l includes/class-woo2etos.php
+```
+

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,29 @@
+=== Woo2Etos ===
+Contributors: simonecansella
+Tags: woocommerce, attribute, size, etos
+Requires at least: 6.0
+Tested up to: 6.5
+Requires PHP: 7.4
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+== Description ==
+Woo2Etos aggrega tutti gli attributi di tipo "taglia" in un unico attributo globale chiamato **Taglia** (`taglia-w2e`) per facilitare l'integrazione con il gestionale Etos. L'attributo aggregato è nascosto dall'editor prodotto e non compare nella scheda "Informazioni aggiuntive".
+
+== Installation ==
+1. Carica la cartella del plugin in `wp-content/plugins/` o installala come file ZIP.
+2. Attiva il plugin dal menu **Plugin** di WordPress.
+3. Visita **WooCommerce > Woo2Etos** per assicurarti che l'attributo sia creato e per avviare la sincronizzazione.
+
+== Frequently Asked Questions ==
+= I termini vuoti vengono rimossi? =
+Sì, la pagina delle impostazioni include uno strumento per eliminare automaticamente i termini senza prodotti associati.
+
+= L'attributo è utilizzabile nei filtri? =
+Sebbene sia nascosto nella pagina prodotto, `taglia-w2e` rimane disponibile per i filtri di categoria e i widget di navigazione.
+
+== Changelog ==
+= 1.0.0 =
+* Prima versione pubblica.
+


### PR DESCRIPTION
## Summary
- Document plugin features and requirements in a new GitHub README
- Add WordPress-style `readme.txt` with description, installation, FAQ and changelog

## Testing
- `php -l woo2etos.php`
- `php -l includes/class-woo2etos.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba81f1eb3483278435d21ae67222e6