### PR TITLE
Add WooCommerce admin notice after sync completion

### DIFF
--- a/includes/class-woo2etos.php
+++ b/includes/class-woo2etos.php
@@ -387,6 +387,17 @@ class Woo2Etos {
             if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
                 error_log( sprintf( '[Woo2Etos] run queued: %d prodotti, %d nuovi termini, %d associazioni', $final['products'], $final['new_terms'], $final['links'] ) );
             }
+            if ( class_exists( 'WC_Admin_Notices' ) ) {
+                $message = sprintf(
+                    'Sincronizzazione completata: %d prodotti, %d nuovi termini, %d associazioni.',
+                    $final['products'],
+                    $final['new_terms'],
+                    $final['links']
+                );
+                WC_Admin_Notices::remove_notice( 'woo2etos_run_success' );
+                WC_Admin_Notices::add_custom_notice( 'woo2etos_run_success', $message );
+                WC_Admin_Notices::save_notices();
+            }
         }
 
         return $res;


### PR DESCRIPTION
## Summary
- show WooCommerce admin notice after finishing product sync

## Testing
- `php -l includes/class-woo2etos.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad20a41fc83279abfd715078aa8ac